### PR TITLE
Load logos from registry

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -18,7 +18,8 @@ switchboard:
     tikaConfigPath: ./tikaConfig.xml
     contactEmail: switchboard@clarin.eu
     tools:
-        toolRegistryPath: ../../switchboard-tool-registry
+        toolRegistryPath: ../../switchboard-tool-registry/tools
+        logoRegistryPath: ../../switchboard-tool-registry/logos
         showOnlyProductionTools: false
     dataStore:
         location: # e.g. /my/data; defaults to temporary storage

--- a/backend/src/main/java/eu/clarin/switchboard/app/config/ToolConfig.java
+++ b/backend/src/main/java/eu/clarin/switchboard/app/config/ToolConfig.java
@@ -12,39 +12,39 @@ public class ToolConfig {
 
     @Valid
     @NotNull
-    private boolean showOnlyProductionTools;
+    private String logoRegistryPath;
 
     @Valid
     @NotNull
-    private boolean includeWebServices;
+    private boolean showOnlyProductionTools;
 
     public ToolConfig() {
     }
 
-    public ToolConfig(String toolRegistryPath, boolean showOnlyProductionTools, boolean includeWebServices) {
+    public ToolConfig(String toolRegistryPath, String logoRegistryPath, boolean showOnlyProductionTools) {
         this.toolRegistryPath = toolRegistryPath;
+        this.logoRegistryPath = logoRegistryPath;
         this.showOnlyProductionTools = showOnlyProductionTools;
-        this.includeWebServices = includeWebServices;
     }
 
     public String getToolRegistryPath() {
         return toolRegistryPath;
     }
 
-    public boolean getShowOnlyProductionTools() {
-        return showOnlyProductionTools;
+    public String getLogoRegistryPath() {
+        return logoRegistryPath;
     }
 
-    public boolean getIncludeWebServices() {
-        return includeWebServices;
+    public boolean getShowOnlyProductionTools() {
+        return showOnlyProductionTools;
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("\ntoolRegistryPath", toolRegistryPath)
+                .add("\nlogoRegistryPath", logoRegistryPath)
                 .add("\nshowOnlyProductionTools", showOnlyProductionTools)
-                .add("\nincludeWebServices", includeWebServices)
                 .toString();
     }
 }

--- a/backend/src/main/java/eu/clarin/switchboard/core/ToolRegistry.java
+++ b/backend/src/main/java/eu/clarin/switchboard/core/ToolRegistry.java
@@ -21,8 +21,13 @@ public class ToolRegistry {
 
     public List<Tool> filterTools(String mediatype, String language, boolean onlyProductionTools) {
         Predicate<Tool> filterMediatypes = tool -> mediatype == null || mediatype.isEmpty() || tool.getMediatypes().contains(mediatype);
-        Predicate<Tool> filterLanguages = tool -> language == null || language.isEmpty() || tool.getLanguages().contains(language);
+
+        // accept tools with matching languages, or tools with 'generic' language input
+        Predicate<Tool> filterLanguages = tool -> language == null || language.isEmpty()
+                || tool.getLanguages().contains(language) || tool.getLanguages().contains("generic");
+
         Predicate<Tool> filterDeployment = tool -> !onlyProductionTools || tool.getDeployment().equalsIgnoreCase(PRODUCTION_DEPLOYMENT);
+
         Predicate<Tool> filter = filterDeployment.and(filterLanguages).and(filterMediatypes);
         return tools.get()
                 .stream()

--- a/backend/src/main/java/eu/clarin/switchboard/resources/ToolsResource.java
+++ b/backend/src/main/java/eu/clarin/switchboard/resources/ToolsResource.java
@@ -1,5 +1,6 @@
 package eu.clarin.switchboard.resources;
 
+import com.google.common.io.ByteStreams;
 import eu.clarin.switchboard.app.config.ToolConfig;
 import eu.clarin.switchboard.core.Tool;
 import eu.clarin.switchboard.core.ToolRegistry;
@@ -9,6 +10,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLConnection;
@@ -58,7 +60,7 @@ public class ToolsResource {
             data = Files.readAllBytes(logo);
         } else {
             LOGGER.debug("logo not found, trying to find it in resources: " + logoName);
-            data = this.readSmallResource(logoName);
+            data = readResource(logoName);
         }
 
         if (data == null) {
@@ -74,18 +76,14 @@ public class ToolsResource {
                 .build();
     }
 
-    private byte[] readSmallResource(String name) throws IOException {
-        InputStream is = this.getClass().getResourceAsStream("/webui/images/" + name);
-        if (is == null) {
-            return null;
-        }
-        byte[] buf = new byte[1024 * 1024];
-        int count = is.read(buf);
-        is.close();
-        if (count > 0) {
-            return Arrays.copyOfRange(buf, 0, count);
-        } else {
-            return new byte[0];
+    private byte[] readResource(String name) throws IOException {
+        try (InputStream is = this.getClass().getResourceAsStream("/webui/images/" + name)) {
+            if (is == null) {
+                return null;
+            }
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ByteStreams.copy(is, baos);
+            return baos.toByteArray();
         }
     }
 }

--- a/backend/src/main/java/eu/clarin/switchboard/resources/ToolsResource.java
+++ b/backend/src/main/java/eu/clarin/switchboard/resources/ToolsResource.java
@@ -5,12 +5,16 @@ import eu.clarin.switchboard.core.Tool;
 import eu.clarin.switchboard.core.ToolRegistry;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 
 @Path("")
@@ -41,5 +45,47 @@ public class ToolsResource {
         List<Tool> tools = toolRegistry.filterTools(mediatype, language, onlyProd);
         tools.sort((t1, t2) -> t1.getName().compareToIgnoreCase(t2.getName()));
         return Response.ok(tools).build();
+    }
+
+    @GET
+    @Path("logos/{logoName}")
+    public Response getTools(@PathParam("logoName") String logoName) throws IOException {
+        String imageMimeType = URLConnection.guessContentTypeFromName(logoName);
+        java.nio.file.Path logo = Paths.get(toolConfig.getLogoRegistryPath(), logoName);
+
+        byte[] data;
+        if (logo.toFile().exists()) {
+            data = Files.readAllBytes(logo);
+        } else {
+            LOGGER.debug("logo not found, trying to find it in resources: " + logoName);
+            data = this.readSmallResource(logoName);
+        }
+
+        if (data == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        StreamingOutput fileStream = output -> {
+            output.write(data);
+            output.flush();
+        };
+        return Response
+                .ok(fileStream, imageMimeType)
+                .build();
+    }
+
+    private byte[] readSmallResource(String name) throws IOException {
+        InputStream is = this.getClass().getResourceAsStream("/webui/images/" + name);
+        if (is == null) {
+            return null;
+        }
+        byte[] buf = new byte[1024 * 1024];
+        int count = is.read(buf);
+        is.close();
+        if (count > 0) {
+            return Arrays.copyOfRange(buf, 0, count);
+        } else {
+            return new byte[0];
+        }
     }
 }

--- a/webui/src/components/ToolList.jsx
+++ b/webui/src/components/ToolList.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { processLanguage, image } from '../actions/utils';
 import { getInvocationURL } from '../actions/toolcall';
+import { apiPath } from '../constants';
 
 const SPACE_REGEX = /\s/;
 const RE_ESCAPE_REGEX = /[-\/\\^$*+?.()|[\]{}]/g;
@@ -161,7 +162,7 @@ class ToolSubList extends React.Component {
                 }
                 { !this.state.show ? false : tools.map(tool =>
                     <ToolCard key={tool.name}
-                        imgSrc={image(tool.logo)}
+                        imgSrc={apiPath.logo(tool.logo)}
                         showTask={this.props.showTask}
                         tool={tool}
                         resource={this.props.resource}

--- a/webui/src/constants.jsx
+++ b/webui/src/constants.jsx
@@ -7,6 +7,7 @@ export const apiPath = {
     languages:  `${urlRoot}/api/languages`,
     tools:      `${urlRoot}/api/tools`,
     storage:    `${urlRoot}/api/storage`,
+    logo:       name => `${urlRoot}/api/logos/${name}`,
 };
 
 export const clientPath = {


### PR DESCRIPTION
**WARNING**  This PR requires another change of the configuration file, the addition of the `logoRegistryPath` entry. This PR should be deployed at the same time as https://github.com/clarin-eric/switchboard-tool-registry/pull/24, but not absolutely necessary if the config file is updated as needed.

fixes #15 