### PR TITLE
Misc ui updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [2.1.0] - 2019-06-26
+## [2.1.1] -
+	- fix footer hiding content in Safari
+	- track tool match calls and tool invocation calls in Matomo
+	- update documentation
+	- add configuration option for hiding development tools
+
+## [2.1.0] - 2019-10-07
 	- fully rewritten and redesigned UI as single page app (React+Redux & react-router)
 	- updated Switchboard API to allow it being called from any repository (any origin)
 

--- a/backend/src/main/java/eu/clarin/switchboard/core/xc/SwitchboardExceptionMapper.java
+++ b/backend/src/main/java/eu/clarin/switchboard/core/xc/SwitchboardExceptionMapper.java
@@ -95,11 +95,11 @@ public class SwitchboardExceptionMapper implements javax.ws.rs.ext.ExceptionMapp
             } else if (exception.getHttpCode() == HttpURLConnection.HTTP_FORBIDDEN) {
                 json.message = "Forbidden access to resource.";
             } else if (exception.getHttpCode() / 100 == 4) {
-                json.message = "Unexpected http client error from resource.";
+                json.message = "Unexpected HTTP client error from resource.";
             } else if (exception.getHttpCode() / 100 == 5) {
-                json.message = "Unexpected http server error from resource.";
+                json.message = "Unexpected HTTP server error from resource.";
             } else {
-                json.message = "Unexpected http status code from resource.";
+                json.message = "Unexpected HTTP status code from resource.";
             }
         } else {
             LOGGER.error("unknown LinkException", exception);

--- a/webui/src/components/Input.jsx
+++ b/webui/src/components/Input.jsx
@@ -77,7 +77,7 @@ export class Input extends React.Component {
                             style={{resize: 'vertical'}}
                             onChange={this.handleChangeLink}
                             rows="2"
-                            placeholder="Enter an URL or a handle"
+                            placeholder="Enter a URL or a handle"
                             value={this.state.link} />
                         <div className="input-group-addon" style={{minWidth:'1em'}}>
                             <button type="submit" className="btn-primary btn"

--- a/webui/src/components/ToolList.jsx
+++ b/webui/src/components/ToolList.jsx
@@ -154,7 +154,7 @@ class ToolSubList extends React.Component {
         return (
             <div className="tool-sublist" onClick={toggle.bind(this, 'show')}>
                 { !this.props.task ? false :
-                    <h3>
+                    <h3 style={{color:'#444'}}>
                         <Indicator title={"chevron-" + (this.state.show ? "down":"right")} style={{fontSize:"75%", marginRight:4}}/>
                         <Highlighter text={this.props.task}/>
                     </h3>
@@ -199,14 +199,20 @@ class ToolCard extends React.Component {
         const Highlighter = this.props.highlighter;
         return (
             <dl className="dl-horizontal header">
-                <dt><img src={imgSrc}/></dt>
+                <dt>
+                    <Indicator title={"chevron-" + (this.state.showDetails ? "down":"right")}
+                                style={{fontSize:"75%", marginRight:0, color:'#444'}}>
+                        <img src={imgSrc}/>
+                    </Indicator>
+                </dt>
                 <dd>
                     { invocationURL
                         ? <a className="btn btn-success" style={{marginRight:16}} onClick={trackCall} href={invocationURL} target="_blank"> Start Tool </a>
                         : false
                     }
+                    <Highlighter text={tool.name} style={{fontSize:"120%"}}/>
                     <a style={{fontSize: 20}} onClick={stopBubbling} href={tool.homepage} target="_blank">
-                        <Highlighter text={tool.name}/>
+                        <Indicator title={"link"} style={{marginLeft:4, fontSize:"75%"}}></Indicator>
                     </a>
                 </dd>
             </dl>
@@ -308,7 +314,7 @@ function escapeRegExp(string) {
 function highlighter(terms) {
     let re_string = "("+terms.map(escapeRegExp).join("|")+")";
     let splitter = new RegExp(re_string, 'gi');
-    return function({text}) {
+    return function({text, style}) {
         // Split on higlight term and include term into parts, ignore case
         let parts = text.split(splitter);
         let spans = parts.map((part, i) => ({
@@ -317,7 +323,7 @@ function highlighter(terms) {
             highlight: terms.some(term => term.toLowerCase() === part.toLowerCase()),
         }));
         return (
-            <span>
+            <span style={style}>
                 { spans.map(({key, text, highlight}) =>
                     <span key={key} className={highlight ? "highlight" : ""}>
                         { text }

--- a/webui/src/components/ToolList.jsx
+++ b/webui/src/components/ToolList.jsx
@@ -189,7 +189,13 @@ class ToolCard extends React.Component {
     };
 
     renderHeader(imgSrc, tool, invocationURL) {
-        const trackCall = () => _paq.push(['trackEvent', 'Tools', 'StartTool', tool.name]);
+        const stopBubbling = (e) => {
+            e.stopPropagation();
+        }
+        const trackCall = (e) => {
+            stopBubbling(e);
+            _paq.push(['trackEvent', 'Tools', 'StartTool', tool.name]);
+        }
         const Highlighter = this.props.highlighter;
         return (
             <dl className="dl-horizontal header">
@@ -199,7 +205,7 @@ class ToolCard extends React.Component {
                         ? <a className="btn btn-success" style={{marginRight:16}} onClick={trackCall} href={invocationURL} target="_blank"> Start Tool </a>
                         : false
                     }
-                    <a style={{fontSize: 20}} href={tool.homepage} target="_blank">
+                    <a style={{fontSize: 20}} onClick={stopBubbling} href={tool.homepage} target="_blank">
                         <Highlighter text={tool.name}/>
                     </a>
                 </dd>


### PR DESCRIPTION
- update changelog to 2.1.1 (without date)
- correct some UI typos
- show signifier for tool expansion
- move hyperlink from tool title to link icon 

Now the UI looks like this:
![Screen Shot 2019-10-31 at 13 33 59](https://user-images.githubusercontent.com/231453/67947137-39f4c000-fbe3-11e9-8c19-33dabdd22d0a.png)
