### PR TITLE
Show badge for unsafe tools

### DIFF
--- a/backend/src/main/resources/webui/css/switchboard.css
+++ b/backend/src/main/resources/webui/css/switchboard.css
@@ -227,6 +227,11 @@ div.tool .badge-holder.standalone > span {
     color: #38e;
 }
 
+div.tool .badge-holder.unsafe > span {
+    color: #fff;
+    background-color: #f66;
+}
+
 div.tool .dl-horizontal {
     margin-top:8px;
     margin-bottom:0;

--- a/backend/src/main/resources/webui/css/switchboard.css
+++ b/backend/src/main/resources/webui/css/switchboard.css
@@ -228,8 +228,7 @@ div.tool .badge-holder.standalone > span {
 }
 
 div.tool .badge-holder.unsafe > span {
-    color: #fff;
-    background-color: #f66;
+    padding: 4px 8px;
 }
 
 div.tool .dl-horizontal {

--- a/webui/src/components/ToolList.jsx
+++ b/webui/src/components/ToolList.jsx
@@ -280,6 +280,10 @@ class ToolCard extends React.Component {
                             : <div className="badge-holder standalone" title="This tool requires local installation on one of your devices, please check the details.">
                                 <span className={"fa fa-download"} aria-hidden="true"/>
                             </div> }
+                        { tool.webApplication && tool.webApplication.url && tool.webApplication.url.startsWith("http://") ?
+                            <div className="badge-holder unsafe" title="The connection to this tool is not secure. Unauthorized parties can spy on your data.">
+                                <span className={"fa fa-eye"} aria-hidden="true"/>
+                            </div>: null }
                     </div>
                 </div>
             </div>

--- a/webui/src/components/ToolList.jsx
+++ b/webui/src/components/ToolList.jsx
@@ -281,7 +281,7 @@ class ToolCard extends React.Component {
                                 <span className={"fa fa-download"} aria-hidden="true"/>
                             </div> }
                         { tool.webApplication && tool.webApplication.url && tool.webApplication.url.startsWith("http://") ?
-                            <div className="badge-holder unsafe" title="The connection to this tool is not secure. Unauthorized parties can spy on your data.">
+                            <div className="badge-holder unsafe" title="The connection to this tool is not secure. Unauthorized 3rd parties can potentially access the resource while we transfer it to the tool.">
                                 <span className={"fa fa-eye"} aria-hidden="true"/>
                             </div>: null }
                     </div>

--- a/webui/src/components/ToolList.jsx
+++ b/webui/src/components/ToolList.jsx
@@ -282,7 +282,7 @@ class ToolCard extends React.Component {
                             </div> }
                         { tool.webApplication && tool.webApplication.url && tool.webApplication.url.startsWith("http://") ?
                             <div className="badge-holder unsafe" title="The connection to this tool is not secure. Unauthorized 3rd parties can potentially access the resource while we transfer it to the tool.">
-                                <span className={"fa fa-eye"} aria-hidden="true"/>
+                                <span><span className={"fa fa-exclamation-triangle"}/> <span> Not secure</span></span>
                             </div>: null }
                     </div>
                 </div>


### PR DESCRIPTION
This PR displays ~a red eye~ a browser-style "not secure" badge for web applications that use the "http" and not "https" protocol (screenshot below). 

<img width="774" alt="Screenshot 2021-02-15 at 16 50 46" src="https://user-images.githubusercontent.com/231453/107968143-48204880-6fae-11eb-952e-28e2699b65d3.png">
