### PR TITLE
Add content inspection for zip files and textual files

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -22,7 +22,6 @@
     </scm>
 
     <dependencies>
-
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>

--- a/backend/src/main/java/eu/clarin/switchboard/core/FileInfo.java
+++ b/backend/src/main/java/eu/clarin/switchboard/core/FileInfo.java
@@ -23,6 +23,9 @@ public class FileInfo {
 
     private boolean selection; // if content is coming from a user selection
 
+    private UUID sourceID; // if this resource is derived from another resource (e.g. zip)
+    private String sourceEntryName; // if this resource is derived from another resource (e.g. zip)
+
     public FileInfo(UUID id, String filename, Path path) {
         this.id = id;
         this.filename = filename;
@@ -71,6 +74,14 @@ public class FileInfo {
         return selection;
     }
 
+    public UUID getSourceID() {
+        return sourceID;
+    }
+
+    public String getSourceEntryName() {
+        return sourceEntryName;
+    }
+
     void setLinksInfo(String originalUrlOrDoiOrHandle, String downloadLink, int redirects) {
         this.originalLink = originalUrlOrDoiOrHandle;
         this.downloadLink = downloadLink;
@@ -86,6 +97,11 @@ public class FileInfo {
         this.selection = selection;
     }
 
+    public void setSource(UUID sourceID, String sourceEntryName) {
+        this.sourceID = sourceID;
+        this.sourceEntryName = sourceEntryName;
+    }
+
     @Override
     public String toString() {
         return "FileInfo: " +
@@ -96,6 +112,8 @@ public class FileInfo {
                 "\noriginalLink='" + originalLink + '\'' +
                 "\nhttpRedirects=" + httpRedirects +
                 "\nselection=" + selection +
+                "\nsourceID=" + sourceID +
+                "\nsourceEntryName=" + sourceEntryName +
                 "\nprofile=" + profile +
                 "\nsecondaryProfiles=" + secondaryProfiles;
     }

--- a/backend/src/main/java/eu/clarin/switchboard/resources/DataResource.java
+++ b/backend/src/main/java/eu/clarin/switchboard/resources/DataResource.java
@@ -3,10 +3,10 @@ package eu.clarin.switchboard.resources;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.MoreObjects;
 import eu.clarin.switchboard.core.FileInfo;
 import eu.clarin.switchboard.core.MediaLibrary;
-import eu.clarin.switchboard.core.xc.CommonException;
-import eu.clarin.switchboard.profiler.api.ProfilingException;
+import eu.clarin.switchboard.profiler.api.Profile;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.slf4j.Logger;
@@ -15,17 +15,22 @@ import org.slf4j.LoggerFactory;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URI;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.zip.ZipFile;
 
 @Path("/api/storage")
 public class DataResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataResource.class);
-    private static final long MAX_INLINE_CONTENT = 1024;
+    private static final int MAX_INLINE_CONTENT = 4 * 1024;
 
     static ObjectMapper mapper = new ObjectMapper();
     MediaLibrary mediaLibrary;
@@ -37,13 +42,7 @@ public class DataResource {
     @GET
     @Path("/{id}")
     public Response getFile(@PathParam("id") String idString, @QueryParam("mediatype") String mediatype) throws Throwable {
-        UUID id;
-        try {
-            id = UUID.fromString(idString);
-        } catch (IllegalArgumentException xc) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        }
-        FileInfo fi = mediaLibrary.waitForFileInfo(id);
+        FileInfo fi = getFileInfo(idString);
         if (fi == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
@@ -69,22 +68,17 @@ public class DataResource {
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN + ";charset=utf-8")
     public Response putContent(@PathParam("id") String idString, String content) throws Throwable {
-        UUID id;
-        try {
-            id = UUID.fromString(idString);
-        } catch (IllegalArgumentException xc) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        }
-        FileInfo fi = mediaLibrary.waitForFileInfo(id);
+        FileInfo fi = getFileInfo(idString);
         if (fi == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
+
         String currentMediaType = fi.getProfile().toProfile().getMediaType();
         if (!currentMediaType.equals(MediaType.TEXT_PLAIN)) {
             return Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE).build();
         }
 
-        mediaLibrary.setContent(id, content);
+        mediaLibrary.setContent(fi.getId(), content);
         return Response.ok(content).type(MediaType.TEXT_PLAIN).build();
     }
 
@@ -93,14 +87,7 @@ public class DataResource {
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
     public Response getFileInfo(@Context HttpServletRequest request, @PathParam("id") String idString)
             throws Throwable {
-        UUID id;
-        try {
-            id = UUID.fromString(idString);
-        } catch (IllegalArgumentException xc) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        }
-
-        FileInfo fi = mediaLibrary.waitForFileInfo(id);
+        FileInfo fi = getFileInfo(idString);
         if (fi == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
@@ -119,14 +106,35 @@ public class DataResource {
     public Response postFile(@Context HttpServletRequest request,
                              @FormDataParam("file") InputStream inputStream,
                              @FormDataParam("file") final FormDataContentDisposition contentDispositionHeader,
-                             @FormDataParam("url") String url) throws CommonException, ProfilingException {
+                             @FormDataParam("url") String url,
+                             @FormDataParam("zipID") String zipID,
+                             @FormDataParam("zipEntryName") String zipEntryName,
+                             @FormDataParam("profile") String profileString
+    ) throws Throwable {
         FileInfo fileInfo;
-
         if (contentDispositionHeader != null) {
             String filename = contentDispositionHeader.getFileName();
-            fileInfo = mediaLibrary.addFile(filename, inputStream);
+            fileInfo = mediaLibrary.addFile(filename, inputStream, null);
         } else if (url != null) {
             fileInfo = mediaLibrary.addByUrl(url);
+        } else if (zipID != null && !zipID.isEmpty() && zipEntryName != null && !zipEntryName.isEmpty()) {
+            FileInfo fi = getFileInfo(zipID);
+            if (fi == null) {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+            Profile profile = null;
+            if (profileString != null && !profileString.isEmpty()) {
+                Profile.Flat flat;
+                try {
+                    flat = mapper.readValue(profileString, Profile.Flat.class);
+                } catch (JsonProcessingException xc) {
+                    LOGGER.error("json conversion exception ", xc);
+                    return Response.status(Response.Status.BAD_REQUEST).entity("Bad json profile").build();
+                }
+                profile = flat.toProfile();
+            }
+            fileInfo = mediaLibrary.addFromZip(fi.getPath(), zipEntryName, profile);
+            fileInfo.setSource(fi.getId(), zipEntryName);
         } else {
             return Response.status(400).entity("Please provide either a file or a url to download in the form").build();
         }
@@ -149,16 +157,80 @@ public class DataResource {
         ret.remove("path");
         ret.put("localLink", localLink);
 
-        if (fileInfo.getFileLength() < MAX_INLINE_CONTENT &&
-                fileInfo.getProfile().toProfile().isMediaType("text/plain")) {
-            try {
-                ret.put("content", new String(Files.readAllBytes(fileInfo.getPath())));
-            } catch (IOException e) {
-                LOGGER.warn("Cannot read file to return inline content: " + e.getMessage());
+        // add the file content
+        File file = fileInfo.getPath().toFile();
+        try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
+            byte[] data = new byte[MAX_INLINE_CONTENT];
+            int n = in.read(data);
+            if (n > 0) {
+                String preview = new String(data, 0, n, StandardCharsets.UTF_8);
+                ret.put("content", preview);
             }
+        } catch (IOException e) {
+            LOGGER.warn("Cannot read file to return inline content: " + e.getMessage());
         }
 
         // LOGGER.debug("postFile returns: " + ret);
         return Response.ok(ret).build();
+    }
+
+    @GET
+    @Path("/{id}/outline")
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    public Response getOutline(@Context HttpServletRequest request, @PathParam("id") String idString)
+            throws Throwable {
+        FileInfo fi = getFileInfo(idString);
+        if (fi == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (!fi.getProfile().toProfile().isMediaType("application/zip")) {
+            LOGGER.debug("getOutline returns: no content");
+            return Response.status(Response.Status.NO_CONTENT).build();
+        }
+
+        ZipFile zfile = new ZipFile(fi.getPath().toFile());
+        List<ZipEntry> ret = zfile.stream()
+                .filter(e -> !e.isDirectory() && e.getSize() > 0)
+                .filter(e -> !e.getName().startsWith("__MACOSX/"))
+                .map(e -> new ZipEntry(e.getName(), e.getSize()))
+                .sorted(Comparator.comparing(ZipEntry::getName))
+                .collect(Collectors.toList());
+        return Response.ok(ret).build();
+    }
+
+    private FileInfo getFileInfo(String idString) throws Throwable {
+        UUID id;
+        try {
+            id = UUID.fromString(idString);
+        } catch (IllegalArgumentException xc) {
+            return null;
+        }
+        return mediaLibrary.waitForFileInfo(id);
+    }
+
+    static class ZipEntry {
+        String name;
+        long size;
+
+        public ZipEntry(String name, long size) {
+            this.name = name;
+            this.size = size;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public long getSize() {
+            return size;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                    .add("name", name)
+                    .add("size", size)
+                    .toString();
+        }
     }
 }

--- a/backend/src/main/java/eu/clarin/switchboard/resources/MainResource.java
+++ b/backend/src/main/java/eu/clarin/switchboard/resources/MainResource.java
@@ -134,7 +134,7 @@ public class MainResource {
             return IndexView.fileInfoID(id, popup);
         } else if (selection != null && !selection.isEmpty()) {
             ByteArrayInputStream bais = new ByteArrayInputStream(selection.getBytes(StandardCharsets.UTF_8));
-            FileInfo fileInfo = mediaLibrary.addFile("selection", bais);
+            FileInfo fileInfo = mediaLibrary.addFile("selection", bais, null);
             fileInfo.setSelection(true);
             Quirks.fillInfoBasedOnOrigin(fileInfo, origin);
             return IndexView.fileInfoID(fileInfo.getId(), popup);

--- a/backend/src/main/resources/webui/css/switchboard.css
+++ b/backend/src/main/resources/webui/css/switchboard.css
@@ -1,6 +1,7 @@
 /* to set footer at page bottom */
 html, body, #reactapp { height: 100%; }
 body { overflow-x:hidden; }
+pre {margin:0; border:none;background-color:transparent;}
 #bodycontainer {
     height: auto;
     min-height: 100%;
@@ -81,7 +82,7 @@ div.resource {
 
 div.resource .resource-header {
     font-size: 20px;
-    margin: 0 0 6px 0;
+    margin: 5px 0 6px 0;
 }
 
 div.resource .namesize {
@@ -89,18 +90,36 @@ div.resource .namesize {
     color: #31708f;
     background-color: #d9edf7;
     border-color: #bce8f1;
-    padding: 15px;
+    padding: 20px 10px 15px;
     margin-bottom: 20px;
     border: 1px solid transparent;
     border-radius: 4px;
 }
-
 div.resource .content > input {
     border: 1px solid #ccc;
     border-radius: 6px;
     padding: 10px;
     color: black;
     width: 100%;
+}
+
+div.resource .content {
+    background: #f2faff;
+    border-radius: 0 0 20px 20px;
+    margin-bottom: 10px;
+    margin-top: -22px;
+    padding: 4px;
+}
+
+div.resource .dependent {
+    margin-left: 1em;
+}
+
+div.resource .disabled .namesize {
+    background-color: #eee;
+}
+div.resource .disabled .content {
+    background-color: #fafafa;
 }
 
 div.resource .namesize span {
@@ -111,9 +130,10 @@ div.more-data-button {
     padding-bottom: 1em;
 }
 div.more-data-pane {
-    border: 2px solid #008;
+    border: 2px solid #ddd;
     padding: 1em;
     border-radius: 4px;
+    background-color: #eee;
 }
 div.more-data-button .glyphicon, div.more-data-pane .glyphicon {
     font-size: 80%;
@@ -269,9 +289,6 @@ div.tool .keyword {
 
 /* custom form css instead of using bootstrap's css
    which breaks the "floating: right" behaviour */
-.tool-list-with-controls form.controls {
-    /*margin-top:1em;*/
-}
 .tool-list-with-controls form.controls label {
     white-space: nowrap;
     vertical-align: middle;
@@ -298,8 +315,12 @@ div.tool .keyword {
 
 @media (min-width: 992px) {
     div.resource .namesize {
-        margin-top: 1.2em;
+        margin-top: 10px;
     }
+    div.resource .resource-header {
+        font-size: 16px;
+    }
+
 }
 
 @media (max-width: 768px) {

--- a/backend/src/test/java/eu/clarin/switchboard/core/LinkMetadataTest.java
+++ b/backend/src/test/java/eu/clarin/switchboard/core/LinkMetadataTest.java
@@ -40,8 +40,8 @@ public class LinkMetadataTest {
         info = LinkMetadata.getLinkData(cachingClient, "https://b2drop.eudat.eu/s/ekDJNz7fWw69w5Y");
         assertEquals("sherlock-short.txt", info.filename);
 
-        info = LinkMetadata.getLinkData(cachingClient, "https://google.com/maps");
-        assertEquals("maps", info.filename);
+        info = LinkMetadata.getLinkData(cachingClient, "https://google.com/trends");
+        assertEquals("trends", info.filename);
     }
 
     @Test

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -3763,9 +3763,9 @@
             "dev": true
         },
         "node_modules/dns-packet": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-            "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.3.tgz",
+            "integrity": "sha512-dDwDMOJU+m6Qx+LhltSV+BWNrMaTqx3eXkAqgt/iouWTXGZMffg1rOSnG2xa3lWqmJ9xTBc7fgIe/css4S1rxA==",
             "dev": true,
             "dependencies": {
                 "ip": "^1.1.0",
@@ -3920,18 +3920,18 @@
             "dev": true
         },
         "node_modules/elliptic": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
             "dev": true,
             "dependencies": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
                 "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "node_modules/elliptic/node_modules/bn.js": {
@@ -10051,9 +10051,9 @@
             }
         },
         "node_modules/ssri": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
-            "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+            "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
             "dev": true,
             "dependencies": {
                 "minipass": "^3.1.1"
@@ -10918,9 +10918,9 @@
             }
         },
         "node_modules/url-parse": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+            "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
             "dev": true,
             "dependencies": {
                 "querystringify": "^2.1.1",
@@ -11856,9 +11856,9 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "3.11.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz",
-            "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
+            "version": "3.11.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz",
+            "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
             "dev": true,
             "dependencies": {
                 "ansi-html": "0.0.7",
@@ -12824,9 +12824,9 @@
             }
         },
         "node_modules/webpack/node_modules/ssri": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-            "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+            "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
             "dev": true,
             "dependencies": {
                 "figgy-pudding": "^3.5.1"
@@ -16263,9 +16263,9 @@
             "dev": true
         },
         "dns-packet": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-            "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.3.tgz",
+            "integrity": "sha512-dDwDMOJU+m6Qx+LhltSV+BWNrMaTqx3eXkAqgt/iouWTXGZMffg1rOSnG2xa3lWqmJ9xTBc7fgIe/css4S1rxA==",
             "dev": true,
             "requires": {
                 "ip": "^1.1.0",
@@ -16386,18 +16386,18 @@
             "dev": true
         },
         "elliptic": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
                 "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
             },
             "dependencies": {
                 "bn.js": {
@@ -21298,9 +21298,9 @@
             }
         },
         "ssri": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
-            "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+            "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
             "dev": true,
             "requires": {
                 "minipass": "^3.1.1"
@@ -21987,9 +21987,9 @@
             }
         },
         "url-parse": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+            "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
             "dev": true,
             "requires": {
                 "querystringify": "^2.1.1",
@@ -23030,9 +23030,9 @@
                     "dev": true
                 },
                 "ssri": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-                    "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+                    "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
                     "dev": true,
                     "requires": {
                         "figgy-pudding": "^3.5.1"
@@ -23144,9 +23144,9 @@
             }
         },
         "webpack-dev-server": {
-            "version": "3.11.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz",
-            "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
+            "version": "3.11.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz",
+            "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",

--- a/webui/src/actions/actions.jsx
+++ b/webui/src/actions/actions.jsx
@@ -136,8 +136,18 @@ export function addZipEntryToInputs(zipRes, zipEntry) {
         }
         const entry = outline.find(e => e.name === zipEntry.name);
         if (entry.checked) {
-            // already checked
-            return;
+            if (state.apiinfo?.enableMultipleResources) {
+                entry.checked = false;
+                const resource = state.resourceList.find(r =>
+                    r.sourceID === zipRes.id && r.sourceEntryName === zipEntry.name);
+                if (resource) {
+                    dispatch(removeResource(resource));
+                }
+                return;
+            } else {
+                // single resource, already checked
+                return;
+            }
         } else {
             entry.checked = true;
         }

--- a/webui/src/actions/actions.jsx
+++ b/webui/src/actions/actions.jsx
@@ -129,7 +129,7 @@ export function selectResourceMatch(toolName, matchIndex) {
     }
 }
 
-export function addZipEntryToInputs(zipRes, zipEntry) {
+export function toggleZipEntryToInputs(zipRes, zipEntry) {
     return function (dispatch, getState) {
         const state = getState();
 

--- a/webui/src/actions/reducers.jsx
+++ b/webui/src/actions/reducers.jsx
@@ -48,17 +48,27 @@ function allTools(state = SI([]), action) {
 }
 
 function resourceList(state = SI([]), action) {
-    let ret = state.asMutable();
+    let ret = SI.asMutable(state);
     switch (action.type) {
         case actionType.RESOURCE_CLEAR_ALL: {
             ret = [];
         }
         break;
 
+        case actionType.RESOURCE_REMOVE_SOURCE: {
+            for (let index = 0; index < ret.length; index++) {
+                const r = ret[index];
+                if (action.data.has(r.id)) {
+                    ret[index] = SI.without(r, ['sourceID', 'sourceEventName']);
+                }
+            }
+        }
+        break;
+
         case actionType.RESOURCE_UPDATE: {
             const index = state.findIndex(r => r.id === action.data.id);
             if (index >= 0) {
-                ret[index] = Object.assign({}, ret[index].asMutable(), action.data);
+                ret[index] = Object.assign({}, SI.asMutable(ret[index]), action.data);
             } else {
                 let idx = ret.length;
                 if (action.data.sourceID) {
@@ -79,7 +89,7 @@ function resourceList(state = SI([]), action) {
         case actionType.RESOURCE_MERGE: {
             const index = state.findIndex(r => r.id === action.data.id);
             if (index >= 0) {
-                ret[index] = ret[index].merge(action.data);
+                ret[index] = SI.merge(ret[index], action.data);
             }
         }
         break;

--- a/webui/src/actions/reducers.jsx
+++ b/webui/src/actions/reducers.jsx
@@ -48,33 +48,46 @@ function allTools(state = SI([]), action) {
 }
 
 function resourceList(state = SI([]), action) {
+    let ret = state.asMutable();
     switch (action.type) {
         case actionType.RESOURCE_CLEAR_ALL: {
-            return SI([])
+            ret = [];
         }
+        break;
+
         case actionType.RESOURCE_UPDATE: {
             const index = state.findIndex(r => r.id === action.data.id);
             if (index >= 0) {
-                const newstate = state.asMutable();
-                newstate[index] = action.data;
-                return SI(newstate);
+                ret[index] = Object.assign({}, ret[index].asMutable(), action.data);
             } else {
-                const newstate = state.asMutable();
-                newstate.push(action.data);
-                return SI(newstate);
+                ret.push(action.data);
             }
         }
-        case actionType.RESOURCE_REMOVE: {
+        break;
+
+        case actionType.RESOURCE_MERGE: {
             const index = state.findIndex(r => r.id === action.data.id);
             if (index >= 0) {
-                const newstate = state.asMutable();
-                newstate.splice(index, 1);
-                return SI(newstate);
+                ret[index] = ret[index].merge(action.data);
             }
         }
-        default:
-            return state;
+        break;
+
+        case actionType.RESOURCE_REMOVE:{
+            ret = ret.filter(r => !action.data.has(r.id));
+        }
+        break;
     }
+    ret = ret.map(r => {
+        const isContainer = ret.some(r2 => r.id === r2.sourceID);
+        if (r.set) {
+            r = r.set("isContainer", isContainer);
+        } else {
+            r.isContainer = isContainer;
+        }
+        return r;
+    });
+    return SI(ret);
 }
 
 function matchingTools(state = SI({}), action) {

--- a/webui/src/actions/reducers.jsx
+++ b/webui/src/actions/reducers.jsx
@@ -60,7 +60,18 @@ function resourceList(state = SI([]), action) {
             if (index >= 0) {
                 ret[index] = Object.assign({}, ret[index].asMutable(), action.data);
             } else {
-                ret.push(action.data);
+                let idx = ret.length;
+                if (action.data.sourceID) {
+                    let i = ret.findIndex(r => r.id === action.data.sourceID);
+                    if (i >= 0) {
+                        i++;
+                        while (i < ret.length && ret[i].sourceID) {
+                            i ++;
+                        }
+                        idx = i;
+                    }
+                }
+                ret.splice(idx, 0, action.data);
             }
         }
         break;

--- a/webui/src/actions/utils.jsx
+++ b/webui/src/actions/utils.jsx
@@ -48,6 +48,23 @@ export function isNotDictionaryTool(tool) {
     return !isDictionaryTool(tool);
 }
 
+const TEXT_TYPES = new Set([
+    "model/prs.ply",
+    "model/prs.obj",
+]);
+
+export function isTextProfile(mediatype) {
+    return mediatype.startsWith("text") || TEXT_TYPES.has(mediatype);
+}
+
+export function isContainerProfile(mediatype) {
+    return mediatype == 'application/zip';
+}
+
+export function isViewableProfile(mediatype) {
+    return isTextProfile(mediatype) || isContainerProfile(mediatype);
+}
+
 const LANG_MAP = {}; // will be initialized by addLanguageMapping
 
 export function addLanguageMapping(codeAndName) {

--- a/webui/src/components/Main.jsx
+++ b/webui/src/components/Main.jsx
@@ -50,7 +50,7 @@ export class Main extends React.Component {
                               resourceList={this.props.resourceList}
                               setResourceProfile={this.props.setResourceProfile}
                               setResourceContent={this.props.setResourceContent}
-                              addZipEntryToInputs={this.props.addZipEntryToInputs}
+                              toggleZipEntryToInputs={this.props.toggleZipEntryToInputs}
                               removeResource={this.props.removeResource}
                               matchingTools={this.props.matchingTools}
                               selectResourceMatch={this.props.selectResourceMatch} /> :
@@ -89,7 +89,7 @@ const Analysis = (props) => (
                       resourceList={props.resourceList}
                       setResourceProfile={props.setResourceProfile}
                       setResourceContent={props.setResourceContent}
-                      addZipEntryToInputs={props.addZipEntryToInputs}
+                      toggleZipEntryToInputs={props.toggleZipEntryToInputs}
                       removeResource={props.removeResource} />
         <hr style={{marginTop:0}}/>
 

--- a/webui/src/components/Main.jsx
+++ b/webui/src/components/Main.jsx
@@ -50,6 +50,7 @@ export class Main extends React.Component {
                               resourceList={this.props.resourceList}
                               setResourceProfile={this.props.setResourceProfile}
                               setResourceContent={this.props.setResourceContent}
+                              addZipEntryToInputs={this.props.addZipEntryToInputs}
                               removeResource={this.props.removeResource}
                               matchingTools={this.props.matchingTools}
                               selectResourceMatch={this.props.selectResourceMatch} /> :
@@ -88,6 +89,7 @@ const Analysis = (props) => (
                       resourceList={props.resourceList}
                       setResourceProfile={props.setResourceProfile}
                       setResourceContent={props.setResourceContent}
+                      addZipEntryToInputs={props.addZipEntryToInputs}
                       removeResource={props.removeResource} />
         <hr style={{marginTop:0}}/>
 

--- a/webui/src/components/Resource.jsx
+++ b/webui/src/components/Resource.jsx
@@ -78,11 +78,12 @@ class NormalResource extends React.Component {
                             <div className="row" style={{margin:4, padding:0}} key={entry.name}>
                                 <div className="col-sm-8" style={{padding:0}}>
                                     <label style={{fontWeight:'normal', marginBottom:0}}>
-                                        <input type={this.props.enableMultipleResources ? "checkbox" : "radio"}
-                                            name={entry.name}
-                                            checked={entry.checked || false}
-                                            onChange={() => this.props.addZipEntryToInputs(res, entry)}
-                                            />
+                                        {res.sourceID ? false : // don't show selector in nested zips
+                                            <input type={this.props.enableMultipleResources ? "checkbox" : "radio"}
+                                                name={entry.name}
+                                                onChange={() => this.props.addZipEntryToInputs(res, entry)}
+                                                checked={entry.checked || false} />
+                                        }
                                         {" "}
                                         <span className={"glyphicon glyphicon-file"} aria-hidden="true"/>
                                         {" "}

--- a/webui/src/components/Resource.jsx
+++ b/webui/src/components/Resource.jsx
@@ -81,7 +81,7 @@ class NormalResource extends React.Component {
                                         {res.sourceID ? false : // don't show selector in nested zips
                                             <input type={this.props.enableMultipleResources ? "checkbox" : "radio"}
                                                 name={entry.name}
-                                                onChange={() => this.props.addZipEntryToInputs(res, entry)}
+                                                onChange={() => this.props.toggleZipEntryToInputs(res, entry)}
                                                 checked={entry.checked || false} />
                                         }
                                         {" "}
@@ -198,7 +198,7 @@ export class ResourceList extends React.Component {
                         languages={this.props.languages}
                         setResourceProfile={this.props.setResourceProfile}
                         removeResource={this.props.removeResource}
-                        addZipEntryToInputs={this.props.addZipEntryToInputs}
+                        toggleZipEntryToInputs={this.props.toggleZipEntryToInputs}
                         enableMultipleResources={this.props.enableMultipleResources}
                         res={res} />;
         }

--- a/webui/src/components/ToolList.jsx
+++ b/webui/src/components/ToolList.jsx
@@ -68,7 +68,7 @@ export class ToolListWithControls extends React.Component {
     }
 
     render() {
-        const resourceLength = this.props.resourceList ? this.props.resourceList.length : 0;
+        const resourceLength = (this.props.resourceList || []).filter(r => !r.isContainer).length;
         const {tools, hiddenTools, partial, hiddenPartial} = this.filterTools(
             this.props.tools, resourceLength, this.state.searchString, this.state.searchTerms);
         return (

--- a/webui/src/constants.jsx
+++ b/webui/src/constants.jsx
@@ -35,6 +35,7 @@ export const actionType = [
     'RESOURCE_UPDATE',
     'RESOURCE_MERGE',
     'RESOURCE_REMOVE',
+    'RESOURCE_REMOVE_SOURCE',
     'SELECT_RESOURCE_MATCH',
     'MODE',
     'ERROR',

--- a/webui/src/constants.jsx
+++ b/webui/src/constants.jsx
@@ -10,6 +10,7 @@ export const apiPath = {
     storage:        `${urlRoot}/api/storage`,
     storageID:      id => `${urlRoot}/api/storage/${id}`,
     storageInfo:    id => `${urlRoot}/api/storage/${id}/info`,
+    storageOutline: id => `${urlRoot}/api/storage/${id}/outline`,
     logo:           name => `${urlRoot}/api/logos/${name}`,
 };
 
@@ -32,6 +33,7 @@ export const actionType = [
     'MATCHING_TOOLS_FETCH_SUCCESS',
     'RESOURCE_CLEAR_ALL',
     'RESOURCE_UPDATE',
+    'RESOURCE_MERGE',
     'RESOURCE_REMOVE',
     'SELECT_RESOURCE_MATCH',
     'MODE',

--- a/webui/src/containers/MainContainer.jsx
+++ b/webui/src/containers/MainContainer.jsx
@@ -1,12 +1,12 @@
 import {connect} from 'react-redux';
 import {Main} from '../components/Main';
-import {setResourceProfile, setResourceContent, removeResource, uploadLink, selectResourceMatch, addZipEntryToInputs} from '../actions/actions';
+import {setResourceProfile, setResourceContent, removeResource, uploadLink, selectResourceMatch, toggleZipEntryToInputs} from '../actions/actions';
 
 const mapStateToProps = (state) => (state);
 const mapDispatchToProps = (dispatch) => ({
     setResourceProfile: (id, profileKey, value) => dispatch(setResourceProfile(id, profileKey, value)),
     setResourceContent: (id, content) => dispatch(setResourceContent(id, content)),
-    addZipEntryToInputs: (zipID, zipEntry) => dispatch(addZipEntryToInputs(zipID, zipEntry)),
+    toggleZipEntryToInputs: (zipID, zipEntry) => dispatch(toggleZipEntryToInputs(zipID, zipEntry)),
     removeResource: (res) => dispatch(removeResource(res)),
     uploadLink: (link) => dispatch(uploadLink(link)),
     selectResourceMatch: (toolName, matchIndex) => dispatch(selectResourceMatch(toolName, matchIndex)),

--- a/webui/src/containers/MainContainer.jsx
+++ b/webui/src/containers/MainContainer.jsx
@@ -1,11 +1,12 @@
 import {connect} from 'react-redux';
 import {Main} from '../components/Main';
-import {setResourceProfile, setResourceContent, removeResource, uploadLink, selectResourceMatch} from '../actions/actions';
+import {setResourceProfile, setResourceContent, removeResource, uploadLink, selectResourceMatch, addZipEntryToInputs} from '../actions/actions';
 
 const mapStateToProps = (state) => (state);
 const mapDispatchToProps = (dispatch) => ({
     setResourceProfile: (id, profileKey, value) => dispatch(setResourceProfile(id, profileKey, value)),
     setResourceContent: (id, content) => dispatch(setResourceContent(id, content)),
+    addZipEntryToInputs: (zipID, zipEntry) => dispatch(addZipEntryToInputs(zipID, zipEntry)),
     removeResource: (res) => dispatch(removeResource(res)),
     uploadLink: (link) => dispatch(uploadLink(link)),
     selectResourceMatch: (toolName, matchIndex) => dispatch(selectResourceMatch(toolName, matchIndex)),

--- a/webui/src/index.jsx
+++ b/webui/src/index.jsx
@@ -102,8 +102,8 @@ class Application extends React.Component {
         // // load a text file by default for testing
         // store.dispatch(require("./actions/actions").uploadLink({
         //     url:'https://b2drop.eudat.eu/s/ekDJNz7fWw69w5Y', origin:'b2drop'}))
-        store.dispatch(require("./actions/actions").uploadLink({
-            url:'http://localhost:8000/fii.zip', origin:'local'}))
+        // store.dispatch(require("./actions/actions").uploadLink({
+        //     url:'http://localhost:8000/testzip.zip', origin:'local'}))
     }
 
     render() {

--- a/webui/src/index.jsx
+++ b/webui/src/index.jsx
@@ -102,6 +102,8 @@ class Application extends React.Component {
         // // load a text file by default for testing
         // store.dispatch(require("./actions/actions").uploadLink({
         //     url:'https://b2drop.eudat.eu/s/ekDJNz7fWw69w5Y', origin:'b2drop'}))
+        store.dispatch(require("./actions/actions").uploadLink({
+            url:'http://localhost:8000/fii.zip', origin:'local'}))
     }
 
     render() {


### PR DESCRIPTION
Entries from zip files can be individually selected to be used as input for the tools. Depending on a configuration option, either multiple zip entries or a single one can be used at a time.

<img width="1186" alt="Screenshot 2021-05-27 at 12 37 49" src="https://user-images.githubusercontent.com/231453/119812346-5b657d00-bee8-11eb-9eb2-c0f45792ad48.png">
