### PR TITLE
Allow repos to specialize profile

### DIFF
--- a/backend/src/main/java/eu/clarin/switchboard/core/ArchiveOps.java
+++ b/backend/src/main/java/eu/clarin/switchboard/core/ArchiveOps.java
@@ -1,0 +1,152 @@
+package eu.clarin.switchboard.core;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.io.ByteStreams;
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.zip.ZipFile;
+
+/**
+ * Operations with archives
+ */
+public class ArchiveOps {
+    private static final ch.qos.logback.classic.Logger LOGGER = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(ArchiveOps.class);
+
+    static final long MAX_OUTLINE_ENTRIES = 4 * 1024;
+    static final Predicate<ZEntry> IS_OS_SPECIFIC = e -> e.getName().startsWith("__MACOSX/");
+
+    public static Outline extractOutlineFromZip(File zipfile) throws IOException {
+        try (ZipFile zfile = new ZipFile(zipfile)) {
+            List<ZEntry> outline = zfile.stream()
+                    .filter(e -> !e.isDirectory() && e.getSize() > 0)
+                    .map(e -> new ZEntry(e.getName(), e.getSize()))
+                    .filter(IS_OS_SPECIFIC.negate())
+                    .collect(Collectors.toList());
+            boolean outlineIsIncomplete = false;
+            if (outline.size() > MAX_OUTLINE_ENTRIES) {
+                outline = outline.subList(0, (int) MAX_OUTLINE_ENTRIES);
+                outlineIsIncomplete = true;
+            }
+            return new Outline(outline, outlineIsIncomplete);
+        }
+    }
+
+    public static Outline extractOutlineFromTar(File tarfile) throws IOException {
+        try (BufferedInputStream fis = new BufferedInputStream(new FileInputStream(tarfile));
+             TarArchiveInputStream tais = new TarArchiveInputStream(fis)) {
+            List<ZEntry> outline = new ArrayList<>();
+            boolean outlineIsIncomplete = false;
+            for (TarArchiveEntry entry = tais.getNextTarEntry(); entry != null; entry = tais.getNextTarEntry()) {
+                if (tais.canReadEntryData(entry) && !entry.isDirectory() && entry.getSize() > 0) {
+                    if (outline.size() >= MAX_OUTLINE_ENTRIES) {
+                        outlineIsIncomplete = true;
+                        break;
+                    }
+                    outline.add(new ZEntry(entry.getName(), entry.getSize()));
+                }
+            }
+            return new Outline(outline, outlineIsIncomplete);
+        }
+    }
+
+    public static InputStream extractFileFromTar(File archiveFile, String archiveEntry) throws IOException {
+        BufferedInputStream fis = new BufferedInputStream(new FileInputStream(archiveFile));
+        TarArchiveInputStream tais = new TarArchiveInputStream(fis);
+        for (ArchiveEntry entry = tais.getNextEntry(); entry != null; entry = tais.getNextEntry()) {
+            if (entry.getName().equals(archiveEntry) && tais.canReadEntryData(entry)) {
+                InputStream entryStream = ByteStreams.limit(tais, entry.getSize());
+                return new DependentInputStream(entryStream, tais);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Utility class that wraps an inputstream and takes another additional
+     * input stream. All streams are closed on <pre>close()</pre>.
+     */
+    private static class DependentInputStream extends InputStream implements Closeable {
+        InputStream delegate;
+        InputStream dependent;
+
+        public DependentInputStream(InputStream delegate, InputStream dependent) {
+            this.delegate = delegate;
+            this.dependent = dependent;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return delegate.read();
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+
+            try {
+                delegate.close();
+            } catch (IOException xc) {
+                dependent.close();
+                throw xc;
+            }
+
+            dependent.close();
+        }
+    }
+
+
+    public static class Outline {
+        List<ZEntry> outline;
+        boolean outlineIsIncomplete;
+
+        public Outline(List<ZEntry> outline, boolean outlineIsIncomplete) {
+            this.outline = outline;
+            this.outlineIsIncomplete = outlineIsIncomplete;
+            outline.sort(Comparator.comparing(ZEntry::getName));
+        }
+
+        public List<ZEntry> getOutline() {
+            return outline;
+        }
+
+        public boolean isOutlineIsIncomplete() {
+            return outlineIsIncomplete;
+        }
+    }
+
+    public static class ZEntry {
+        String name;
+        long size;
+
+        public ZEntry(String name, long size) {
+            this.name = name;
+            this.size = size;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public long getSize() {
+            return size;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                    .add("name", name)
+                    .add("size", size)
+                    .toString();
+        }
+    }
+
+}

--- a/backend/src/main/java/eu/clarin/switchboard/resources/DataResource.java
+++ b/backend/src/main/java/eu/clarin/switchboard/resources/DataResource.java
@@ -110,6 +110,7 @@ public class DataResource {
                              @FormDataParam("file") InputStream inputStream,
                              @FormDataParam("file") final FormDataContentDisposition contentDispositionHeader,
                              @FormDataParam("url") String url,
+                             @FormDataParam("mimetype") String mimetype,
                              @FormDataParam("archiveID") String archiveID,
                              @FormDataParam("archiveEntryName") String archiveEntryName,
                              @FormDataParam("profile") String profileString
@@ -119,7 +120,11 @@ public class DataResource {
             String filename = contentDispositionHeader.getFileName();
             fileInfo = mediaLibrary.addFile(filename, inputStream, null);
         } else if (url != null) {
-            fileInfo = mediaLibrary.addByUrl(url);
+            Profile profile = null;
+            if (mimetype != null && !mimetype.isEmpty()) {
+                profile = Profile.builder().mediaType(mimetype).build();
+            }
+            fileInfo = mediaLibrary.addByUrl(url, profile);
         } else if (archiveID != null && !archiveID.isEmpty()) {
             FileInfo fi = getFileInfo(archiveID);
             if (fi == null) {

--- a/backend/src/main/java/eu/clarin/switchboard/resources/DataResource.java
+++ b/backend/src/main/java/eu/clarin/switchboard/resources/DataResource.java
@@ -3,14 +3,12 @@ package eu.clarin.switchboard.resources;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.MoreObjects;
 import com.google.common.io.ByteStreams;
+import eu.clarin.switchboard.core.ArchiveOps;
 import eu.clarin.switchboard.core.Constants;
 import eu.clarin.switchboard.core.FileInfo;
 import eu.clarin.switchboard.core.MediaLibrary;
 import eu.clarin.switchboard.profiler.api.Profile;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.IOUtils;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
@@ -24,16 +22,14 @@ import java.io.*;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.UUID;
 import java.util.zip.ZipException;
-import java.util.zip.ZipFile;
 
 @Path("/api/storage")
 public class DataResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataResource.class);
     private static final int MAX_INLINE_CONTENT = 4 * 1024;
-    private static final long MAX_ZIP_ENTRIES = 4 * 1024;
 
     static ObjectMapper mapper = new ObjectMapper();
     MediaLibrary mediaLibrary;
@@ -202,52 +198,18 @@ public class DataResource {
 
         if (fi.getProfile().toProfile().isMediaType(Constants.MEDIATYPE_ZIP)) {
             try {
-                Outline outline = extractOutlineFromZip(fi.getPath().toFile());
+                ArchiveOps.Outline outline = ArchiveOps.extractOutlineFromZip(fi.getPath().toFile());
                 return Response.ok(outline).build();
             } catch (ZipException xc) {
                 LOGGER.info("bad zip archive: " + xc.getMessage());
                 return Response.status(Response.Status.NOT_ACCEPTABLE).entity(xc.getMessage()).build();
             }
         } else if (fi.getProfile().toProfile().isMediaType(Constants.MEDIATYPE_TAR)) {
-            Outline outline = extractOutlineFromTar(fi.getPath().toFile());
+            ArchiveOps.Outline outline = ArchiveOps.extractOutlineFromTar(fi.getPath().toFile());
             return Response.ok(outline).build();
         }
 
         return Response.status(Response.Status.NO_CONTENT).build();
-    }
-
-    private static Outline extractOutlineFromZip(File zipfile) throws IOException {
-        try (ZipFile zfile = new ZipFile(zipfile)) {
-            List<ZEntry> outline = zfile.stream()
-                    .filter(e -> !e.isDirectory() && e.getSize() > 0)
-                    .filter(e -> !e.getName().startsWith("__MACOSX/"))
-                    .map(e -> new ZEntry(e.getName(), e.getSize()))
-                    .collect(Collectors.toList());
-            boolean outlineIsIncomplete = false;
-            if (outline.size() > MAX_ZIP_ENTRIES) {
-                outline = outline.subList(0, (int) MAX_ZIP_ENTRIES);
-                outlineIsIncomplete = true;
-            }
-            return new Outline(outline, outlineIsIncomplete);
-        }
-    }
-
-    private static Outline extractOutlineFromTar(File tarfile) throws IOException {
-        try (BufferedInputStream fis = new BufferedInputStream(new FileInputStream(tarfile));
-             TarArchiveInputStream tais = new TarArchiveInputStream(fis)) {
-            List<ZEntry> outline = new ArrayList<>();
-            boolean outlineIsIncomplete = false;
-            for (TarArchiveEntry entry = tais.getNextTarEntry(); entry != null; entry = tais.getNextTarEntry()) {
-                if (tais.canReadEntryData(entry) && !entry.isDirectory() && entry.getSize() > 0) {
-                    if (outline.size() >= MAX_ZIP_ENTRIES) {
-                        outlineIsIncomplete = true;
-                        break;
-                    }
-                    outline.add(new ZEntry(entry.getName(), entry.getSize()));
-                }
-            }
-            return new Outline(outline, outlineIsIncomplete);
-        }
     }
 
     private FileInfo getFileInfo(String idString) throws Throwable {
@@ -258,50 +220,5 @@ public class DataResource {
             return null;
         }
         return mediaLibrary.waitForFileInfo(id);
-    }
-
-    static class Outline {
-        List<ZEntry> outline;
-        boolean outlineIsIncomplete;
-
-        public Outline(List<ZEntry> outline, boolean outlineIsIncomplete) {
-            this.outline = outline;
-            this.outlineIsIncomplete = outlineIsIncomplete;
-            outline.sort(Comparator.comparing(ZEntry::getName));
-        }
-
-        public List<ZEntry> getOutline() {
-            return outline;
-        }
-
-        public boolean isOutlineIsIncomplete() {
-            return outlineIsIncomplete;
-        }
-    }
-
-    static class ZEntry {
-        String name;
-        long size;
-
-        public ZEntry(String name, long size) {
-            this.name = name;
-            this.size = size;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public long getSize() {
-            return size;
-        }
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(this)
-                    .add("name", name)
-                    .add("size", size)
-                    .toString();
-        }
     }
 }

--- a/backend/src/main/java/eu/clarin/switchboard/resources/MainResource.java
+++ b/backend/src/main/java/eu/clarin/switchboard/resources/MainResource.java
@@ -8,6 +8,7 @@ import eu.clarin.switchboard.core.MediaLibrary;
 import eu.clarin.switchboard.core.Quirks;
 import eu.clarin.switchboard.core.xc.StorageException;
 import eu.clarin.switchboard.core.xc.StoragePolicyException;
+import eu.clarin.switchboard.profiler.api.Profile;
 import eu.clarin.switchboard.profiler.api.ProfilingException;
 import io.dropwizard.views.View;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
@@ -93,10 +94,11 @@ public class MainResource {
                            @FormDataParam("url") String url,
                            @FormDataParam("id") String id,
                            @FormDataParam("origin") String origin,
+                           @FormDataParam("mimetype") String mimetype,
                            @FormDataParam("selection") String selection,
                            @FormDataParam("popup") boolean popup)
             throws JsonProcessingException, ProfilingException, StorageException, StoragePolicyException {
-        return post(inputStream, contentDispositionHeader, url, id, origin, selection, popup);
+        return post(inputStream, contentDispositionHeader, url, id, origin, mimetype, selection, popup);
     }
 
     @POST
@@ -106,12 +108,13 @@ public class MainResource {
     public View postToIndex(@FormDataParam("file") InputStream inputStream,
                             @FormDataParam("file") final FormDataContentDisposition contentDispositionHeader,
                             @FormDataParam("url") String url,
+                            @FormDataParam("mimetype") String mimetype,
                             @FormDataParam("id") String id,
                             @FormDataParam("origin") String origin,
                             @FormDataParam("selection") String selection,
                             @FormDataParam("popup") boolean popup)
             throws JsonProcessingException, ProfilingException, StorageException, StoragePolicyException {
-        return post(inputStream, contentDispositionHeader, url, id, origin, selection, popup);
+        return post(inputStream, contentDispositionHeader, url, id, origin, mimetype, selection, popup);
     }
 
     public View post(InputStream inputStream,
@@ -119,6 +122,7 @@ public class MainResource {
                      String url,
                      String idParam,
                      String origin,
+                     String mimetype,
                      String selection,
                      boolean popup)
             throws JsonProcessingException, ProfilingException, StoragePolicyException, StorageException {
@@ -127,7 +131,11 @@ public class MainResource {
             UUID id = mediaLibrary.addFileAsync(filename, inputStream);
             return IndexView.fileInfoID(id, popup);
         } else if (url != null) {
-            UUID id = mediaLibrary.addByUrlAsync(url);
+            Profile profile = null;
+            if (mimetype != null && !mimetype.isEmpty()) {
+                profile = Profile.builder().mediaType(mimetype).build();
+            }
+            UUID id = mediaLibrary.addByUrlAsync(url, profile);
             return IndexView.fileInfoID(id, popup);
         } else if (idParam != null) {
             UUID id = UUID.fromString(idParam);

--- a/backend/src/test/java/eu/clarin/switchboard/core/MediaLibraryTest.java
+++ b/backend/src/test/java/eu/clarin/switchboard/core/MediaLibraryTest.java
@@ -70,16 +70,22 @@ public class MediaLibraryTest {
         assert (false); // will not get here
     }
 
+    public void testProfileSpecialization() throws CommonException, ProfilingException {
+        MediaLibrary mediaLibrary = new MediaLibrary(dataStore, profiler, storagePolicy, urlResolver, dataStoreConfig);
+        mediaLibrary.addByUrl("http://this^is&a)bad@url", null);
+    }
+
+
     @Test(expected = LinkException.class)
     public void addMedia1() throws CommonException, ProfilingException {
         MediaLibrary mediaLibrary = new MediaLibrary(dataStore, profiler, storagePolicy, urlResolver, dataStoreConfig);
-        mediaLibrary.addByUrl("http://this^is&a)bad@url");
+        mediaLibrary.addByUrl("http://this^is&a)bad@url", null);
     }
 
     @Test(expected = StoragePolicyException.class)
     public void addMedia2() throws CommonException, ProfilingException {
         MediaLibrary mediaLibrary = new MediaLibrary(dataStore, profiler, storagePolicy, urlResolver, dataStoreConfig);
         // a site that does a HTTP redirect
-        mediaLibrary.addByUrl("http://clarin.eu");
+        mediaLibrary.addByUrl("http://clarin.eu", null);
     }
 }

--- a/backend/src/test/java/eu/clarin/switchboard/core/QuirksTest.java
+++ b/backend/src/test/java/eu/clarin/switchboard/core/QuirksTest.java
@@ -1,0 +1,33 @@
+package eu.clarin.switchboard.core;
+
+import eu.clarin.switchboard.core.xc.LinkException;
+import eu.clarin.switchboard.profiler.api.Profile;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class QuirksTest {
+    @Test
+    public void urlFixSpecialCases() throws LinkException {
+        assertEquals(
+                "https://b2drop.eudat.eu/s/ekDJNz7fWw69w5Y/download",
+                Quirks.urlFixSpecialCases("https://b2drop.eudat.eu/s/ekDJNz7fWw69w5Y"));
+        assertEquals(
+                "https://www.dropbox.com/s/9flyntc1353ve07/id_rsa.pub?dl=1",
+                Quirks.urlFixSpecialCases("https://www.dropbox.com/s/9flyntc1353ve07/id_rsa.pub?dl=0"));
+    }
+
+    @Test
+    public void specializeProfile() {
+        FileInfo fi = new FileInfo(UUID.randomUUID(), "filename", Path.of("/tmp/filename"));
+        fi.setProfiles(Profile.builder().mediaType("text/plain").build(), Collections.emptyList());
+        Profile declaredProfile = Profile.builder().mediaType("text/csv").build();
+        Quirks.specializeProfile(fi, declaredProfile);
+        assertEquals(fi.getProfile().toProfile().getMediaType(), declaredProfile.getMediaType());
+    }
+}


### PR DESCRIPTION
fixes #197 

If the mediatype sent from the repository is a specialization of the detected profile, the declared mediatype is used.

Specialized mediatypes are hardcoded in a map (see the Quirks class). For example, `text/csv` and `text/markdown` are specializations of `text/plain`.

I also refactored all archive operations (tar/zip) into a separate file.