### PR TITLE
Pull UI tests to their own github actions job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Build
         run: |
           make package
+          docker save switchboard/switchboard:latest > switchboard-docker-image.tar
         env:
           CI_VERSION: ${{ needs.prepare.outputs.version }}
       - name: 'Tar post build workspace'
@@ -65,6 +66,7 @@ jobs:
         run: tar -xf workspace.tar
       - name: Test UI
         run: |
+          docker load < switchboard-docker-image.tar
           test/run-end-to-end.sh
           cp build/switchboard.tar.gz build/switchboard-${{ needs.prepare.outputs.version }}.tar.gz
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           name: workspace
           path: workspace.tar
           retention-days: 1
-  test:
+  test-ui:
     needs: [build]
     runs-on: ubuntu-20.04
     steps:
@@ -63,7 +63,7 @@ jobs:
           name: workspace
       - name: 'Untar post build workspace'
         run: tar -xf workspace.tar
-      - name: Test
+      - name: Test UI
         run: |
           test/run-end-to-end.sh
           cp build/switchboard.tar.gz build/switchboard-${{ needs.prepare.outputs.version }}.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - name: 'Tar post build workspace'
         run: tar -cvf workspace.tar .
       - name: Upload workspace package
-      - uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2
         with:
           name: workspace
           path: workspace.tar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
           name: switchboard-build-package
           path: build/switchboard-${{ needs.prepare.outputs.version }}.tar.gz
   release:
-    needs: [prepare, build, test]
+    needs: [prepare, build, test-ui]
     # Run job for github releases and tag pushes (without github release)
     if: github.event_name == 'release' || needs.prepare.outputs.create_release == 'true'
     runs-on: ubuntu-18.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
   - cron: "23 4 12 * *"
 jobs:
   prepare:
+    name: "Prepare"
     runs-on: ubuntu-18.04
     outputs:
       version: ${{ steps.get_version.outputs.VERSION }}
@@ -32,6 +33,7 @@ jobs:
             echo ::set-output name=CREATE_RELEASE::true
           fi
   build:
+    name: "Build"
     needs: [prepare]
     # Run job for: github releases, tag pushes without github release and regular pushes (not tag)
     if: github.event_name == 'release' || !contains(github.ref, 'refs/tags/') || needs.prepare.outputs.create_release == 'true'
@@ -56,6 +58,7 @@ jobs:
           path: workspace.tar
           retention-days: 1
   test-ui:
+    name: "Test UI"
     needs: [build]
     runs-on: ubuntu-20.04
     steps:
@@ -77,6 +80,7 @@ jobs:
           name: switchboard-build-package
           path: build/switchboard-${{ needs.prepare.outputs.version }}.tar.gz
   release:
+    name: "Release"
     needs: [prepare, build, test-ui]
     # Run job for github releases and tag pushes (without github release)
     if: github.event_name == 'release' || needs.prepare.outputs.create_release == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,27 @@ jobs:
       - name: Build
         run: |
           make package
+        env:
+          CI_VERSION: ${{ needs.prepare.outputs.version }}
+      - name: 'Tar post build workspace'
+        run: tar -cvf workspace.tar .
+      - name: Upload workspace package
+      - uses: actions/upload-artifact@v2
+        with:
+          name: workspace
+          path: workspace.tar
+          retention-days: 1
+  test:
+    needs: [build]
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: workspace
+      - name: 'Untar post build workspace'
+        run: tar -xf workspace.tar
+      - name: Test
+        run: |
           test/run-end-to-end.sh
           cp build/switchboard.tar.gz build/switchboard-${{ needs.prepare.outputs.version }}.tar.gz
         env:
@@ -54,7 +75,7 @@ jobs:
           name: switchboard-build-package
           path: build/switchboard-${{ needs.prepare.outputs.version }}.tar.gz
   release:
-    needs: [prepare, build]
+    needs: [prepare, build, test]
     # Run job for github releases and tag pushes (without github release)
     if: github.event_name == 'release' || needs.prepare.outputs.create_release == 'true'
     runs-on: ubuntu-18.04

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DOCKERTAG=switchboard/switchboard:latest
 WEBUIAPP=src/main/resources/webui
 JSBUNDLE=$(WEBUIAPP)/bundle.js
+SWITCHBOARD_URL?=http://localhost:8080
 
 build-docker-image:
 	@GIT_COMMIT=$(shell git log -1 --pretty=format:"%H"|cut -c1-7) ;\
@@ -42,10 +43,10 @@ run-webui-dev-server:
 	(cd webui && node_modules/webpack-dev-server/bin/webpack-dev-server.js --mode development)
 
 run-uitests:
-	(cd webui/test && ../node_modules/cypress/bin/cypress run -q)
+	(cd webui/test && ../node_modules/cypress/bin/cypress run -q -c baseUrl=${SWITCHBOARD_URL})
 
 run-interactive-uitests:
-	(cd webui/test && ../node_modules/cypress/bin/cypress run --headed --no-exit)
+	(cd webui/test && ../node_modules/cypress/bin/cypress run --headed --no-exit -c baseUrl=${SWITCHBOARD_URL})
 
 dependencies:
 	(cd webui && npm install)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ DOCKERTAG=switchboard/switchboard:latest
 WEBUIAPP=src/main/resources/webui
 JSBUNDLE=$(WEBUIAPP)/bundle.js
 SWITCHBOARD_URL?=http://localhost:8080
+NPM_VERSION=8.3.0
 
 build-docker-image:
 	@GIT_COMMIT=$(shell git log -1 --pretty=format:"%H"|cut -c1-7) ;\
@@ -49,7 +50,7 @@ run-interactive-uitests:
 	(cd webui/test && ../node_modules/cypress/bin/cypress run --headed --no-exit -c baseUrl=${SWITCHBOARD_URL})
 
 dependencies:
-	(cd webui && npm install)
+	(cd webui && npm install -g npm@${NPM_VERSION} && npm install)
 
 clean:
 	(cd backend && mvn -q clean)

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,7 @@
 FROM cypress/browsers:node16.5.0-chrome94-ff93
 
 WORKDIR /build
+
 COPY ./Makefile                 .
 COPY ./webui/.babelrc           ./webui/
 COPY ./webui/package.json       ./webui/
@@ -9,8 +10,6 @@ COPY ./webui/webpack.config.js  ./webui/
 COPY ./webui/src                ./webui/src
 COPY ./webui/test               ./webui/test
 
-WORKDIR /build/webui
-RUN npm i cypress
+RUN make dependencies
 
-WORKDIR /build/webui/test
-CMD $(npm bin)/cypress run -q -c baseUrl=http://switchboard:8080
+CMD make run-uitests

--- a/test/compose.yaml
+++ b/test/compose.yaml
@@ -9,6 +9,8 @@ services:
   
   tester:
     image: switchboard/switchboard-tester
+    environment:
+      SWITCHBOARD_URL: http://switchboard:8080
 
 volumes:
   toolsdata: 


### PR DESCRIPTION
Just an idea. 
It takes a bit longer, but is more organized and tests better IMO, since it creates a fresh separate environment for the UI tests