### PR TITLE
Fetch tools only for test UI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,13 +43,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: '50'
-      - name: Fetch tools
-        uses: actions/checkout@v2
-        with:
-          repository: clarin-eric/switchboard-tool-registry
-          ref: production
-          fetch-depth: '1'
-          path: switchboard-tool-registry
       - name: Build
         run: |
           make package


### PR DESCRIPTION
Looks like we do not need to fetch the tools for the "build" job