### PR TITLE
Ask for CMDI files from VCR

### DIFF
--- a/backend/src/main/java/eu/clarin/switchboard/core/DataStore.java
+++ b/backend/src/main/java/eu/clarin/switchboard/core/DataStore.java
@@ -67,10 +67,10 @@ public class DataStore {
         if (dirList == null) {
             return;
         }
-        for (File dir: dirList) {
+        for (File dir : dirList) {
             File[] files = dir.listFiles();
             if (files != null) {
-                for (File f: files) {
+                for (File f : files) {
                     tryDelete(f.toPath());
                 }
             }
@@ -78,11 +78,13 @@ public class DataStore {
         }
     }
 
-    final static String illegalCharsString = "\"'*/:<>?\\|";
-    final static TIntHashSet illegalChars = new TIntHashSet();
+    final static TIntHashSet allowedChars = new TIntHashSet();
 
     static {
-        illegalCharsString.codePoints().forEachOrdered(illegalChars::add);
+        allowedChars.addAll(new int[]{' ', '.', '_', '+', '-', '='});
+        for (int i = '0'; i <= '9'; ++i) allowedChars.add(i);
+        for (int i = 'A'; i <= 'Z'; ++i) allowedChars.add(i);
+        for (int i = 'a'; i <= 'z'; ++i) allowedChars.add(i);
     }
 
     public static String sanitize(String filename) {
@@ -91,8 +93,7 @@ public class DataStore {
         }
         StringBuilder cleanName = new StringBuilder();
         filename.codePoints().forEachOrdered(c -> {
-            boolean replace = c < 32 || illegalChars.contains(c);
-            cleanName.appendCodePoint(replace ? '_' : c);
+            cleanName.appendCodePoint(allowedChars.contains(c) ? c : '_');
         });
         return cleanName.toString();
     }

--- a/backend/src/main/java/eu/clarin/switchboard/core/LinkMetadata.java
+++ b/backend/src/main/java/eu/clarin/switchboard/core/LinkMetadata.java
@@ -63,7 +63,9 @@ public class LinkMetadata {
     public static LinkInfo getLinkData(CloseableHttpClient client, String originalUrlOrDoiOrHandle) throws CommonException {
         String link = resolveDoiOrHandle(originalUrlOrDoiOrHandle);
         link = Quirks.urlFixSpecialCases(link);
-        LOGGER.debug("url fixup: " + originalUrlOrDoiOrHandle + " -> " + link);
+        if (!originalUrlOrDoiOrHandle.equals(link)) {
+            LOGGER.debug("url fixup: " + originalUrlOrDoiOrHandle + " -> " + link);
+        }
 
         // do the http call
         HttpCacheContext context = HttpCacheContext.create();

--- a/backend/src/main/java/eu/clarin/switchboard/core/MediaLibrary.java
+++ b/backend/src/main/java/eu/clarin/switchboard/core/MediaLibrary.java
@@ -2,7 +2,10 @@ package eu.clarin.switchboard.core;
 
 import eu.clarin.switchboard.app.config.DataStoreConfig;
 import eu.clarin.switchboard.app.config.UrlResolverConfig;
-import eu.clarin.switchboard.core.xc.*;
+import eu.clarin.switchboard.core.xc.CommonException;
+import eu.clarin.switchboard.core.xc.LinkException;
+import eu.clarin.switchboard.core.xc.StorageException;
+import eu.clarin.switchboard.core.xc.StoragePolicyException;
 import eu.clarin.switchboard.profiler.api.*;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
@@ -63,9 +66,11 @@ public class MediaLibrary {
                 .setMaxRedirects(MAX_ALLOWED_REDIRECTS)
                 .setRedirectsEnabled(true)
                 .build();
+
         cachingClient = CachingHttpClients.custom()
                 .setCacheConfig(cacheConfig)
                 .setDefaultRequestConfig(requestConfig)
+                .addInterceptorFirst(Quirks.QUIRKS_REQUEST_INTERCEPTOR)
                 .build();
 
         executorService = Executors.newCachedThreadPool();

--- a/backend/src/test/java/eu/clarin/switchboard/core/LinkMetadataTest.java
+++ b/backend/src/test/java/eu/clarin/switchboard/core/LinkMetadataTest.java
@@ -7,14 +7,17 @@ import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClients;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class LinkMetadataTest {
     @Test
-    public void testInfo() throws CommonException {
+    public void testInfo() throws CommonException, IOException {
         CacheConfig cacheConfig = CacheConfig.custom()
                 .setMaxCacheEntries(100)
-                .setMaxObjectSize(1024*1024)
+                .setMaxObjectSize(1024 * 1024)
                 .build();
         RequestConfig requestConfig = RequestConfig.custom()
                 .setConnectTimeout(2000)
@@ -30,18 +33,60 @@ public class LinkMetadataTest {
 
         info = LinkMetadata.getLinkData(cachingClient, "http://doi.org/10.1045/may99-payette");
         assertEquals("05payette.html", info.filename);
+        info.response.close();
 
         info = LinkMetadata.getLinkData(cachingClient, "https://people.sc.fsu.edu/~jburkardt/data/ply/airplane.ply");
         assertEquals("airplane.ply", info.filename);
+        info.response.close();
 
         info = LinkMetadata.getLinkData(cachingClient, "https://raw.githubusercontent.com/clarin-eric/switchboard/master/LICENCE");
         assertEquals("LICENCE", info.filename);
+        info.response.close();
 
         info = LinkMetadata.getLinkData(cachingClient, "https://b2drop.eudat.eu/s/ekDJNz7fWw69w5Y");
         assertEquals("sherlock-short.txt", info.filename);
+        info.response.close();
 
         info = LinkMetadata.getLinkData(cachingClient, "https://google.com/trends");
         assertEquals("trends", info.filename);
+        info.response.close();
+    }
+
+    @Test
+    public void testVcrNegotiation() throws CommonException, IOException {
+        CacheConfig cacheConfig = CacheConfig.custom()
+                .setMaxCacheEntries(100)
+                .setMaxObjectSize(1024 * 1024)
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(2000)
+                .setSocketTimeout(2000)
+                .setMaxRedirects(10)
+                .setRedirectsEnabled(true)
+                .build();
+        CloseableHttpClient cachingClient = CachingHttpClients.custom()
+                .setCacheConfig(cacheConfig)
+                .setDefaultRequestConfig(requestConfig)
+                .addInterceptorFirst(Quirks.QUIRKS_REQUEST_INTERCEPTOR)
+                .build();
+        LinkMetadata.LinkInfo info;
+        String contentType;
+
+        info = LinkMetadata.getLinkData(cachingClient, "https://doi.org/10.34733/vc-1061");
+        contentType = info.response.getFirstHeader("content-type").getValue();
+        assertEquals("application/x-cmdi+xml", contentType);
+        info.response.close();
+
+        info = LinkMetadata.getLinkData(cachingClient, "https://collections.clarin.eu/service/v1/collections//1061");
+        contentType = info.response.getFirstHeader("content-type").getValue();
+        System.out.println("contentType = " + contentType);
+        assertEquals("application/x-cmdi+xml", contentType);
+        info.response.close();
+
+        info = LinkMetadata.getLinkData(cachingClient, "https://alpha-collections.clarin.eu/service/v1/collections//1060");
+        contentType = info.response.getFirstHeader("content-type").getValue();
+        assertEquals("application/x-cmdi+xml", contentType);
+        info.response.close();
     }
 
     @Test

--- a/backend/src/test/java/eu/clarin/switchboard/core/MediaLibraryTest.java
+++ b/backend/src/test/java/eu/clarin/switchboard/core/MediaLibraryTest.java
@@ -68,14 +68,6 @@ public class MediaLibraryTest {
         assert (false); // will not get here
     }
 
-    public void testProfileSpecialization() throws CommonException, ProfilingException {
-        MediaLibrary mediaLibrary = new MediaLibrary(
-                dataStore, profiler, profiler.getTextExtractor(),
-                storagePolicy, urlResolver, dataStoreConfig);
-        mediaLibrary.addByUrl("http://this^is&a)bad@url", null);
-    }
-
-
     @Test(expected = LinkException.class)
     public void addMedia1() throws CommonException, ProfilingException {
         MediaLibrary mediaLibrary = new MediaLibrary(


### PR DESCRIPTION
When we ask for files from the VCR (clarin collections) we inject an "accept:application/*" header which ensures that we'll get back a cmdi file. Otherwise we'd get back an html file which is less useful.